### PR TITLE
位置参数不对应

### DIFF
--- a/03-search-r1/train.py
+++ b/03-search-r1/train.py
@@ -554,14 +554,14 @@ def main(args: argparse.Namespace) -> None:
                     leave=False,
                 ) as rollout_progress:
                     # 为每道题采样 group_size 条多轮搜索轨迹，并计算 reward 和组内 advantage。
-                   trajectories = rollout_batch(
-                    sampling_client=sampling_client,
-                    tokenizer=tokenizer,
-                    search_client=search_client,
-                    examples=batch,
-                    config=rollout_config,
-                    progress_callback=rollout_progress.update,
-                )
+                    trajectories = rollout_batch(
+                        sampling_client=sampling_client,
+                        tokenizer=tokenizer,
+                        search_client=search_client,
+                        examples=batch,
+                        config=rollout_config,
+                        progress_callback=rollout_progress.update,
+                    )
 
                 # 每条有训练信号的完整轨迹只构造一个 Datum，再按 padding 矩形动态装箱。
                 training_progress.set_postfix(phase="build datums", refresh=True)

--- a/03-search-r1/train.py
+++ b/03-search-r1/train.py
@@ -554,14 +554,14 @@ def main(args: argparse.Namespace) -> None:
                     leave=False,
                 ) as rollout_progress:
                     # 为每道题采样 group_size 条多轮搜索轨迹，并计算 reward 和组内 advantage。
-                    trajectories = rollout_batch(
-                        sampling_client,
-                        tokenizer,
-                        search_client,
-                        batch,
-                        rollout_config,
-                        progress_callback=rollout_progress.update,
-                    )
+                   trajectories = rollout_batch(
+                    sampling_client=sampling_client,
+                    tokenizer=tokenizer,
+                    search_client=search_client,
+                    examples=batch,
+                    config=rollout_config,
+                    progress_callback=rollout_progress.update,
+                )
 
                 # 每条有训练信号的完整轨迹只构造一个 Datum，再按 padding 矩形动态装箱。
                 training_progress.set_postfix(phase="build datums", refresh=True)


### PR DESCRIPTION
按位置传参的话， batch （问题列表）会被赋给 sampling_client 参数， sampling_client 被赋给 tokenizer ，依此类推。每个参数实际接收到的值和参数名含义对不上，到真正调用 .sample_async() 的时候就会 AttributeError 。要么改定义（把 examples 放第一个），要么改调用（ examples=batch 用关键字传参）。按项目惯例，调用侧改最合理