### PR TITLE
fix: remove obsolete PyTRIO client close calls

### DIFF
--- a/01-grpo/01-demo-sync.py
+++ b/01-grpo/01-demo-sync.py
@@ -707,7 +707,6 @@ def main(config: GRPOConfig) -> None:
     finally:
         if swanlab_run is not None:
             swanlab_run.finish()
-        training_client.close()
 
 
 if __name__ == "__main__":

--- a/01-grpo/02-demo-async.py
+++ b/01-grpo/02-demo-async.py
@@ -786,7 +786,6 @@ async def main(config: GRPOConfig) -> None:
     finally:
         if swanlab_run is not None:
             swanlab_run.finish()
-        await training_client.close_async()
 
 
 if __name__ == "__main__":

--- a/02-opd/general-opd/01-demo-sync.py
+++ b/02-opd/general-opd/01-demo-sync.py
@@ -389,10 +389,9 @@ def main(args: argparse.Namespace) -> None:
         if run is not None:
             swanlab.log({"save/weights_path": swanlab.Text(save_result.path)}, step=args.steps)
     finally:
-        # 无论中间是否报错，都尽量正常结束日志和远程训练 client。
+        # 无论中间是否报错，都尽量正常结束日志。
         if run is not None:
             swanlab.finish()
-        training_client.close()
 
 
 if __name__ == "__main__":

--- a/02-opd/general-opd/02-demo-async.py
+++ b/02-opd/general-opd/02-demo-async.py
@@ -348,7 +348,6 @@ async def main(args: argparse.Namespace) -> None:
     print(f"Loaded {len(dataset)} DeepMath prompts")
 
     service_client = trio.ServiceClient()
-    training_client = None
     swanlab_run = None
 
     try:
@@ -476,11 +475,9 @@ async def main(args: argparse.Namespace) -> None:
         if swanlab_run is not None:
             swanlab.log({"save/weights_path": swanlab.Text(save_result.path)}, step=args.steps)
     finally:
-        # 无论中间是否报错，都尽量正常结束日志和远程训练 client。
+        # 无论中间是否报错，都尽量正常结束日志。
         if swanlab_run is not None:
             swanlab.finish()
-        if training_client is not None:
-            await training_client.close_async()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

项目当前锁定 `pytrio==0.2.4`，但部分同步和异步示例仍然调用：

- `TrainingClient.close()`
- `TrainingClient.close_async()`

这两个接口从 PyTRIO 0.2.2 开始已被移除。训练和权重保存成功后，程序会在清理阶段抛出：

```text
AttributeError: 'TrainingClient' object has no attribute 'close'
```

PyTRIO 0.2.4 已通过内部 finalizer 管理 TrainingClient 和共享运行时资源，因此不需要显式调用关闭接口。

<img width="916" height="433" alt="截屏2026-07-27 15 13 22" src="https://github.com/user-attachments/assets/cfbdab15-1099-4c28-907d-5c06eed9a7d8" />

## 修改
1. 删除 GRPO 同步和异步示例中失效的 client 关闭调用。
2. 删除 General OPD 同步和异步示例中失效的关闭调用。
3. 更新相关清理注释。
4. 删除异步 OPD 示例中不再需要的 training_client = None。
PyTRIO 0.2.4 已通过内部 finalizer 管理 TrainingClient 和共享运行时资源，因此不需要显式调用关闭接口。

## 验证
修改后重新复现，问题未出现。

<img width="941" height="335" alt="截屏2026-07-27 15 15 21" src="https://github.com/user-attachments/assets/01ca701e-6db0-4c6a-b80f-64119dc1c7b6" />
